### PR TITLE
Datadog now namespaces its statsd implementation

### DIFF
--- a/lib/datadog/notifications/reporter.rb
+++ b/lib/datadog/notifications/reporter.rb
@@ -1,6 +1,6 @@
 module Datadog
   class Notifications
-    class Reporter < ::Statsd
+    class Reporter < ::Datadog::Statsd
     end
   end
 end


### PR DESCRIPTION
Since there is no version constraint on the dependency on dogstatsd gem when doing bundle update we ran into a problem with that you are referencing something named ::Statsd that all of a sudden doesn't exist anymore.

My change is not intended to be merged right of the bat just wanted to open a discussion and point to the problem.